### PR TITLE
Fix compilation on macOS

### DIFF
--- a/src/Cardinal.h
+++ b/src/Cardinal.h
@@ -4,11 +4,7 @@
 
 #define R_NO_REMAP
 
-extern "C"
-{
-  #include <Rinternals.h>
-}
-
+#include <Rinternals.h>
 #include "utils.h"
 
 extern "C" {


### PR DESCRIPTION
<Rinternals.h> provides its own `extern "C"`, and on macOS wrapping it again catches some C++ headers within `extern "C"`, leading to errors. (See also bioconda/bioconda-recipes#25275.)