### PR TITLE
Resolved typo about MSImagingArrays inheriting from SpectralImagingArrays

### DIFF
--- a/vignettes/Cardinal3-guide.Rmd
+++ b/vignettes/Cardinal3-guide.Rmd
@@ -195,9 +195,9 @@ A "processed" imzML file contains mass spectra where each spectrum has its own *
 
 - `SpectralImagingData`: Virtual container for spectral imaging data, i.e., spectra with spatial metadata
 
-- `MSImagingArrays`: Specializes `SpectralImagingData` (via `SpectralImagingExperiment`)  for representing raw mass spectra where each spectrum has its own *m/z* values
+- `MSImagingArrays`: Specializes `SpectralImagingData` (via `SpectralImagingArrays`)  for representing raw mass spectra where each spectrum has its own *m/z* values
 
-- `MSImagingExperiment`: Specializes `SpectralImagingData` (via `SpectralImagingArrays`)  for representing mass spectra where all spectra have the same *m/z* values
+- `MSImagingExperiment`: Specializes `SpectralImagingData` (via `SpectralImagingExperiment`)  for representing mass spectra where all spectra have the same *m/z* values
 
 These are further explored in the next sections.
 


### PR DESCRIPTION
The user guide says that `MSImagingArrays` specializes `SpectralImagingData` via `SpectralImagingExperiment` when it does via `SpectralImagingArrays`. 

Similarly, `MSImagingExperiment` specializes `SpectralImagingData` via `SpectralImagingExperiment` but the user guide notes that it specializes via `SpectraImagingArrays`. 
