### PR TITLE
bug(process-spectra): rename 'bi' to 'bilateral' in the smoothing fun…

### DIFF
--- a/R/process-spectra.R
+++ b/R/process-spectra.R
@@ -74,7 +74,7 @@ setMethod("smooth", "SpectralImagingData",
 .smooth_fun <- list(
 	gaussian = function(x, t, ...) 
 		matter::filt1_gauss(x, ...),
-	bi = function(x, t, ...) 
+	bilateral = function(x, t, ...) 
 		matter::filt1_bi(x, ...),
 	adaptive = function(x, t, ...) 
 		matter::filt1_adapt(x, ...),


### PR DESCRIPTION
bug(process-spectra): rename 'bi' to 'bilateral' in the smoothing function to fix the bug where the bilateral filter could not be used due to the 'bi' naming