### PR TITLE
Add GHA CI skeleton

### DIFF
--- a/.github/workflows/devel-build.yml
+++ b/.github/workflows/devel-build.yml
@@ -1,0 +1,13 @@
+name: Cardinal CI workflow
+run-name: Cardinal CI workflow run
+on:
+  - push
+jobs:
+  build:
+    # TODO confirm the base image we should use. "latest"
+    # leaves us open to unexpected breakage if there's a
+    # breaking change in the base image; we should control
+    # when we update the base.
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Running the Cardinal CI workflow. Triggered by ${{ github.event_name }}"


### PR DESCRIPTION
Adds a Github Actions workflow to the repo to be triggered on pull requests and on pushes to the repo. Right now the workflow is a no-op; adding meaningful build, test, and deploy steps will come later once we have signal that the infrastructure is working.